### PR TITLE
Enhance accessibility of functionality table

### DIFF
--- a/tasks/compatibility.rake
+++ b/tasks/compatibility.rake
@@ -49,7 +49,7 @@ namespace :evaluation do
       @vendor_results.each do |_vendor, results|
         results.each_with_index do |(method, supported), line|
           lines[line] = "#{method}" unless lines[line]
-          lines[line] << "|#{supported}"
+          lines[line] << "|#{supported ? '&#10003;' : '&#10007;'}"
         end
       end
 


### PR DESCRIPTION
A really minor suggestion while scanning the `README.md`.

We might use &#10003; and &#10007; instead of `true` and `false` which is easier to distinguish in my opinion.
Additionally, green and red colors might be used if this is still not enough.

What do you think?
